### PR TITLE
공지사항 검색 결과가 없는 키워드를 추가할 때 경고하는 기능 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     kaptAndroidTest "com.google.dagger:hilt-android-compiler:$hilt_version"
     androidTestAnnotationProcessor "com.google.dagger:hilt-android-compiler:$hilt_version"
 
+    // Retrofit2
+    androidTestImplementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+
     // firebase
     implementation platform('com.google.firebase:firebase-bom:30.2.0')
     implementation 'com.google.firebase:firebase-analytics-ktx'

--- a/app/src/androidTest/java/com/foundy/hansungnotification/KeywordActivityTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/KeywordActivityTest.kt
@@ -17,6 +17,7 @@ import com.foundy.domain.usecase.keyword.AddKeywordUseCase
 import com.foundy.domain.usecase.keyword.ReadKeywordListUseCase
 import com.foundy.domain.usecase.keyword.RemoveKeywordUseCase
 import com.foundy.domain.usecase.notice.GetNoticeListUseCase
+import com.foundy.domain.usecase.notice.HasSearchResultUseCase
 import com.foundy.domain.usecase.notice.SearchNoticeListUseCase
 import com.foundy.hansungnotification.fake.FakeFavoriteRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeFirebaseRepositoryImpl
@@ -63,7 +64,8 @@ class KeywordActivityTest {
         RemoveKeywordUseCase(fakeKeywordRepository),
         SubscribeToUseCase(fakeFirebaseRepository),
         UnsubscribeFromUseCase(fakeFirebaseRepository),
-        IsSignedInUseCase(fakeFirebaseRepository)
+        IsSignedInUseCase(fakeFirebaseRepository),
+        HasSearchResultUseCase(fakeNoticeRepository)
     )
     lateinit var context: Context
 

--- a/app/src/androidTest/java/com/foundy/hansungnotification/KeywordFragmentTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/KeywordFragmentTest.kt
@@ -17,8 +17,10 @@ import com.foundy.domain.usecase.firebase.UnsubscribeFromUseCase
 import com.foundy.domain.usecase.keyword.AddKeywordUseCase
 import com.foundy.domain.usecase.keyword.ReadKeywordListUseCase
 import com.foundy.domain.usecase.keyword.RemoveKeywordUseCase
+import com.foundy.domain.usecase.notice.HasSearchResultUseCase
 import com.foundy.hansungnotification.fake.FakeFirebaseRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeKeywordRepositoryImpl
+import com.foundy.hansungnotification.fake.FakeNoticeRepositoryImpl
 import com.foundy.hansungnotification.utils.waitForView
 import com.foundy.hansungnotification.utils.withIndex
 import com.foundy.presentation.R
@@ -55,6 +57,7 @@ class KeywordFragmentTest {
 
     private val fakeKeywordRepository = FakeKeywordRepositoryImpl()
     private val fakeFirebaseRepository = FakeFirebaseRepositoryImpl()
+    private val fakeNoticeRepository = FakeNoticeRepositoryImpl()
 
     @BindValue
     val keywordViewModel = KeywordViewModel(
@@ -63,7 +66,8 @@ class KeywordFragmentTest {
         RemoveKeywordUseCase(fakeKeywordRepository),
         SubscribeToUseCase(fakeFirebaseRepository),
         UnsubscribeFromUseCase(fakeFirebaseRepository),
-        IsSignedInUseCase(fakeFirebaseRepository)
+        IsSignedInUseCase(fakeFirebaseRepository),
+        HasSearchResultUseCase(fakeNoticeRepository)
     )
 
     private lateinit var context: Context

--- a/app/src/androidTest/java/com/foundy/hansungnotification/KeywordViewModelTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/KeywordViewModelTest.kt
@@ -1,0 +1,133 @@
+package com.foundy.hansungnotification
+
+import com.foundy.domain.exception.NoSearchResultException
+import com.foundy.domain.usecase.firebase.IsSignedInUseCase
+import com.foundy.domain.usecase.firebase.SubscribeToUseCase
+import com.foundy.domain.usecase.firebase.UnsubscribeFromUseCase
+import com.foundy.domain.usecase.keyword.AddKeywordUseCase
+import com.foundy.domain.usecase.keyword.ReadKeywordListUseCase
+import com.foundy.domain.usecase.keyword.RemoveKeywordUseCase
+import com.foundy.domain.usecase.notice.HasSearchResultUseCase
+import com.foundy.hansungnotification.fake.FakeFirebaseRepositoryImpl
+import com.foundy.hansungnotification.fake.FakeKeywordRepositoryImpl
+import com.foundy.hansungnotification.fake.FakeNoticeRepositoryImpl
+import com.foundy.presentation.utils.KeywordValidator
+import com.foundy.presentation.view.keyword.KeywordViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class KeywordViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val fakeKeywordRepository = FakeKeywordRepositoryImpl()
+    private val fakeFirebaseRepository = FakeFirebaseRepositoryImpl()
+    private val fakeNoticeRepository = FakeNoticeRepositoryImpl()
+
+    private val viewModel = KeywordViewModel(
+        ReadKeywordListUseCase(fakeKeywordRepository),
+        AddKeywordUseCase(fakeKeywordRepository),
+        RemoveKeywordUseCase(fakeKeywordRepository),
+        SubscribeToUseCase(fakeFirebaseRepository),
+        UnsubscribeFromUseCase(fakeFirebaseRepository),
+        IsSignedInUseCase(fakeFirebaseRepository),
+        HasSearchResultUseCase(fakeNoticeRepository),
+        testDispatcher
+    )
+
+    @Test
+    fun callsOnFailureWithKeywordInvalidException_IfKeywordIsInvalid() {
+        var onSuccessCount = 0
+        lateinit var exception: Exception
+
+        viewModel.checkKeywordSubmit(
+            "@장학금",
+            onSuccess = { onSuccessCount++ },
+            onFailure = { exception = it },
+            onFinally = {}
+        )
+
+        assertEquals(0, onSuccessCount)
+        assertTrue(exception is KeywordValidator.KeywordInvalidException)
+    }
+
+    @Test
+    fun callsOnFailureWithNoSearchResultException_IfKeywordHasNoSearchResult() {
+        fakeNoticeRepository.setHasSearchResult(Result.success(false))
+
+        var onSuccessCount = 0
+        lateinit var exception: Exception
+
+        viewModel.checkKeywordSubmit(
+            "장학금",
+            onSuccess = { onSuccessCount++ },
+            onFailure = { exception = it },
+            onFinally = {}
+        )
+
+        assertEquals(0, onSuccessCount)
+        assertTrue(exception is NoSearchResultException)
+    }
+
+    @Test
+    fun callsOnFailureWithHttpException_IfSearchResultIsFailure() {
+        val responseBody = ResponseBody.create(MediaType.get("text/html; charset=UTF-8"), "")
+        val response = Response.error<ResponseBody>(404, responseBody)
+        fakeNoticeRepository.setHasSearchResult(Result.failure(HttpException(response)))
+
+        var onSuccessCount = 0
+        lateinit var exception: Exception
+
+        viewModel.checkKeywordSubmit(
+            "장학금",
+            onSuccess = { onSuccessCount++ },
+            onFailure = { exception = it },
+            onFinally = {}
+        )
+
+        assertEquals(0, onSuccessCount)
+        assertTrue(exception is HttpException)
+    }
+
+    @Test
+    fun callsOnSuccess_IfKeywordPassesChecks() {
+        fakeNoticeRepository.setHasSearchResult(Result.success(true))
+
+        var onSuccessCount = 0
+        var exception: Exception? = null
+
+        viewModel.checkKeywordSubmit(
+            "장학금",
+            onSuccess = { onSuccessCount++ },
+            onFailure = { exception = it },
+            onFinally = {}
+        )
+
+        assertEquals(1, onSuccessCount)
+        assertTrue(exception == null)
+    }
+
+    @Test
+    fun callsOnFinally_Whenever() {
+        fakeNoticeRepository.setHasSearchResult(Result.failure(Exception()))
+
+        var onFinallyCount = 0
+
+        viewModel.checkKeywordSubmit(
+            "2o3ij$@!",
+            onSuccess = {},
+            onFailure = {},
+            onFinally = { onFinallyCount++ }
+        )
+
+        assertEquals(1, onFinallyCount)
+    }
+}

--- a/app/src/androidTest/java/com/foundy/hansungnotification/SearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/SearchViewModelTest.kt
@@ -44,15 +44,15 @@ class SearchViewModelTest {
         searchViewModel.recentQueries.observeForTesting {
             runBlocking {
                 searchViewModel.addOrUpdateRecent(query1)
-                delay(50)
+                delay(100)
                 assertEquals(1, searchViewModel.recentQueries.value?.size)
 
                 searchViewModel.addOrUpdateRecent(query1)
-                delay(50)
+                delay(100)
                 assertEquals(1, searchViewModel.recentQueries.value?.size)
 
                 searchViewModel.addOrUpdateRecent(query2)
-                delay(50)
+                delay(100)
                 assertEquals(2, searchViewModel.recentQueries.value?.size)
             }
         }

--- a/app/src/androidTest/java/com/foundy/hansungnotification/fake/FakeNoticeRepositoryImpl.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/fake/FakeNoticeRepositoryImpl.kt
@@ -10,10 +10,15 @@ class FakeNoticeRepositoryImpl: NoticeRepository {
 
     private val sharedFlow = MutableSharedFlow<PagingData<Notice>>()
     private val noticeList = mutableListOf<Notice>()
+    private var hasSearchResult = Result.success(true)
 
     fun setFakeList(notices: List<Notice>) {
         noticeList.clear()
         noticeList.addAll(notices)
+    }
+
+    fun setHasSearchResult(result: Result<Boolean>) {
+        hasSearchResult = result
     }
 
     suspend fun emitFake() {
@@ -23,4 +28,6 @@ class FakeNoticeRepositoryImpl: NoticeRepository {
     override fun getNoticeList() = sharedFlow
 
     override fun searchNoticeList(query: String) = emptyFlow<PagingData<Notice>>()
+
+    override suspend fun hasSearchResult(query: String) = hasSearchResult
 }

--- a/data/src/main/java/com/foundy/data/constant/WebConstant.kt
+++ b/data/src/main/java/com/foundy/data/constant/WebConstant.kt
@@ -1,0 +1,20 @@
+package com.foundy.data.constant
+
+
+object WebConstant {
+
+    const val START_PAGE = 1
+
+    /**
+     * Post 요청에 쓰일 파라미터를 생성한다.
+     *
+     * 만약 추후에 한성대 사이트가 리뉴얼 되는 경우 크롬 검사에 들어가 네트워크 탭에서 해당 파일을 고른 후 페이로드 항목을
+     * 확인하면 된다.
+     */
+    fun createSearchPostParameter(query: String): HashMap<String, Any> {
+        return hashMapOf(
+            "srchWrd" to query,
+            "srchColumn" to "sj"
+        )
+    }
+}

--- a/data/src/main/java/com/foundy/data/repository/NoticeRepositoryImpl.kt
+++ b/data/src/main/java/com/foundy/data/repository/NoticeRepositoryImpl.kt
@@ -4,11 +4,15 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import com.foundy.data.api.NoticeApi
+import com.foundy.data.constant.WebConstant
+import com.foundy.data.constant.WebConstant.START_PAGE
+import com.foundy.data.mapper.NoticeMapper
 import com.foundy.data.source.notice.NoticePagingSource
 import com.foundy.data.source.notice.SearchingNoticePagingSource
 import com.foundy.domain.model.Notice
 import com.foundy.domain.repository.NoticeRepository
 import kotlinx.coroutines.flow.Flow
+import retrofit2.HttpException
 import javax.inject.Inject
 
 class NoticeRepositoryImpl @Inject constructor(
@@ -31,5 +35,22 @@ class NoticeRepositoryImpl @Inject constructor(
             config = PagingConfig(pageSize = NOTICE_PAGE_SIZE),
             pagingSourceFactory = { SearchingNoticePagingSource(noticeApi, query = query) }
         ).flow
+    }
+
+    override suspend fun hasSearchResult(query: String): Result<Boolean> {
+        return try {
+            val response = noticeApi.searchNoticeList(
+                page = START_PAGE,
+                param = WebConstant.createSearchPostParameter(query)
+            )
+            if (response.isSuccessful) {
+                val notices = NoticeMapper(response.body()!!).filter { !it.isHeader }
+                Result.success(notices.isNotEmpty())
+            } else {
+                Result.failure(HttpException(response))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 }

--- a/data/src/main/java/com/foundy/data/source/notice/NoticePagingSource.kt
+++ b/data/src/main/java/com/foundy/data/source/notice/NoticePagingSource.kt
@@ -3,6 +3,7 @@ package com.foundy.data.source.notice
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.foundy.data.api.NoticeApi
+import com.foundy.data.constant.WebConstant.START_PAGE
 import com.foundy.data.mapper.NoticeMapper
 import com.foundy.domain.model.Notice
 import kotlinx.coroutines.Dispatchers
@@ -14,10 +15,6 @@ import javax.inject.Inject
 class NoticePagingSource @Inject constructor(
     private val noticeApi: NoticeApi
 ) : PagingSource<Int, Notice>() {
-
-    companion object {
-        const val START_PAGE = 1
-    }
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Notice> {
         val page = params.key ?: START_PAGE

--- a/data/src/main/java/com/foundy/data/source/notice/SearchingNoticePagingSource.kt
+++ b/data/src/main/java/com/foundy/data/source/notice/SearchingNoticePagingSource.kt
@@ -3,6 +3,8 @@ package com.foundy.data.source.notice
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.foundy.data.api.NoticeApi
+import com.foundy.data.constant.WebConstant
+import com.foundy.data.constant.WebConstant.START_PAGE
 import com.foundy.data.mapper.NoticeMapper
 import com.foundy.domain.model.Notice
 import kotlinx.coroutines.Dispatchers
@@ -16,30 +18,13 @@ class SearchingNoticePagingSource @Inject constructor(
     private val query: String
 ) : PagingSource<Int, Notice>() {
 
-    companion object {
-        const val START_PAGE = 1
-    }
-
-    /**
-     * Post 요청에 쓰일 파라미터를 생성한다.
-     *
-     * 만약 추후에 한성대 사이트가 리뉴얼 되는 경우 크롬 검사에 들어가 네트워크 탭에서 해당 파일을 고른 후 페이로드 항목을
-     * 확인하면 된다.
-     */
-    private fun createParameter() : HashMap<String, Any> {
-        return hashMapOf(
-            "srchWrd" to query,
-            "srchColumn" to "sj"
-        )
-    }
-
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Notice> {
         val page = params.key ?: START_PAGE
         return try {
             val response = withContext(Dispatchers.IO) {
                 noticeApi.searchNoticeList(
                     page = page,
-                    param = createParameter()
+                    param = WebConstant.createSearchPostParameter(query)
                 )
             }
             val responseBody = response.body()

--- a/domain/src/main/java/com/foundy/domain/exception/NoSearchResultException.kt
+++ b/domain/src/main/java/com/foundy/domain/exception/NoSearchResultException.kt
@@ -1,0 +1,3 @@
+package com.foundy.domain.exception
+
+class NoSearchResultException : Exception("공지로 등록된 적이 없는 키워드입니다. 그래도 등록하시겠습니까?")

--- a/domain/src/main/java/com/foundy/domain/repository/NoticeRepository.kt
+++ b/domain/src/main/java/com/foundy/domain/repository/NoticeRepository.kt
@@ -7,4 +7,5 @@ import kotlinx.coroutines.flow.Flow
 interface NoticeRepository {
     fun getNoticeList(): Flow<PagingData<Notice>>
     fun searchNoticeList(query: String): Flow<PagingData<Notice>>
+    suspend fun hasSearchResult(query: String): Result<Boolean>
 }

--- a/domain/src/main/java/com/foundy/domain/usecase/notice/HasSearchResultUseCase.kt
+++ b/domain/src/main/java/com/foundy/domain/usecase/notice/HasSearchResultUseCase.kt
@@ -1,0 +1,10 @@
+package com.foundy.domain.usecase.notice
+
+import com.foundy.domain.repository.NoticeRepository
+import javax.inject.Inject
+
+class HasSearchResultUseCase @Inject constructor(
+    private val repository: NoticeRepository
+) {
+    suspend operator fun invoke(query: String) = repository.hasSearchResult(query)
+}

--- a/presentation/src/main/java/com/foundy/presentation/di/DispatcherModule.kt
+++ b/presentation/src/main/java/com/foundy/presentation/di/DispatcherModule.kt
@@ -15,6 +15,6 @@ class DispatcherModule {
 
     @Singleton
     @Provides
-    @Named("RecentQuery")
-    fun provideRecentQueryDispatchers(): CoroutineDispatcher = Dispatchers.IO
+    @Named("Main")
+    fun provideMainDispatchers(): CoroutineDispatcher = Dispatchers.Main
 }

--- a/presentation/src/main/java/com/foundy/presentation/extension/ViewExtension.kt
+++ b/presentation/src/main/java/com/foundy/presentation/extension/ViewExtension.kt
@@ -2,15 +2,21 @@ package com.foundy.presentation.extension
 
 import android.content.Context
 import android.graphics.Color
+import android.graphics.drawable.Drawable
 import android.graphics.drawable.InsetDrawable
+import android.os.SystemClock
 import android.util.TypedValue
+import android.view.KeyEvent
 import android.view.View
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.annotation.ColorRes
 import androidx.annotation.DimenRes
 import androidx.annotation.IntRange
+import androidx.core.content.res.getDrawableOrThrow
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.textfield.TextInputLayout
 
 
 fun View.addRipple() = with(TypedValue()) {
@@ -39,4 +45,51 @@ fun View.setBackgroundColor(@ColorRes id: Int, @IntRange(from = 0, to = 255) alp
     val green: Int = Color.green(resourceColor)
     val color = Color.argb(alpha, red, green, blue)
     setBackgroundColor(color)
+}
+
+fun Context.getProgressBarDrawable(): Drawable {
+    val value = TypedValue()
+    theme.resolveAttribute(android.R.attr.progressBarStyleSmall, value, false)
+    val progressBarStyle = value.data
+    val attributes = intArrayOf(android.R.attr.indeterminateDrawable)
+    val array = obtainStyledAttributes(progressBarStyle, attributes)
+    val drawable = array.getDrawableOrThrow(0)
+    array.recycle()
+    return drawable
+}
+
+fun TextView.setOnEditorActionListenerWithDebounce(
+    debounceTime: Long = 1000L,
+    action: (actionId: Int) -> Boolean
+) {
+    this.setOnEditorActionListener(object : TextView.OnEditorActionListener {
+        private var lastClickTime: Long = 0
+
+        override fun onEditorAction(v: TextView?, actionId: Int, event: KeyEvent?): Boolean {
+            if (SystemClock.elapsedRealtime() - lastClickTime < debounceTime) {
+                return true
+            }
+
+            lastClickTime = SystemClock.elapsedRealtime()
+            return action(actionId)
+        }
+    })
+}
+
+fun TextInputLayout.setEndIconOnClickListenerWithDebounce(
+    debounceTime: Long = 1000L,
+    action: () -> Unit
+) {
+    this.setEndIconOnClickListener(object : View.OnClickListener {
+        private var lastClickTime: Long = 0
+
+        override fun onClick(v: View?) {
+            if (SystemClock.elapsedRealtime() - lastClickTime < debounceTime) {
+                return
+            }
+
+            lastClickTime = SystemClock.elapsedRealtime()
+            action()
+        }
+    })
 }

--- a/presentation/src/main/java/com/foundy/presentation/utils/KeywordValidator.kt
+++ b/presentation/src/main/java/com/foundy/presentation/utils/KeywordValidator.kt
@@ -14,7 +14,7 @@ object KeywordValidator {
     class AlreadyExistsException : KeywordInvalidException("이미 존재하는 키워드입니다.")
     class InvalidCharacterException : KeywordInvalidException("완성된 한글과 숫자만 입력할 수 있어요.")
 
-    operator fun invoke(keyword: String, registeredKeywordList: List<Keyword>): Boolean {
+    fun check(keyword: String, registeredKeywordList: List<Keyword>): Boolean {
         if (keyword.length < MIN_LENGTH) throw MinLengthException()
         if (!PATTERN.matcher(keyword).matches()) throw InvalidCharacterException()
         if (registeredKeywordList.any { it.title == keyword }) throw AlreadyExistsException()

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
@@ -121,7 +122,10 @@ class KeywordFragment(
             } catch (e: KeywordValidator.KeywordInvalidException) {
                 showSnackBar(e.message ?: getString(R.string.invalid_keyword))
             } catch (e: NoSearchResultException) {
-                showSnackBar(e.message ?: getString(R.string.invalid_keyword))
+                showAlertDialog(e.message ?: getString(R.string.invalid_keyword)) {
+                    addKeyword(keyword)
+                    textInput.setText("")
+                }
             } catch (e: HttpException) {
                 showSnackBar(getString(R.string.check_internet_connection))
             } catch (e: Exception) {
@@ -181,5 +185,17 @@ class KeywordFragment(
 
     private fun showSnackBar(message: String) {
         Snackbar.make(requireView(), message, Snackbar.LENGTH_SHORT).show()
+    }
+
+    private fun showAlertDialog(message: String, onSubmit: () -> Unit) {
+        val alertDialog: AlertDialog? = activity?.let {
+            val builder = AlertDialog.Builder(it).apply {
+                setPositiveButton(R.string.submit) { _, _ -> onSubmit() }
+                setNegativeButton(R.string.cancel) { _, _ -> }
+                setTitle(message)
+            }
+            builder.create()
+        }
+        alertDialog?.show()
     }
 }

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
@@ -208,7 +208,7 @@ class KeywordFragment(
             val builder = AlertDialog.Builder(it).apply {
                 setPositiveButton(R.string.submit) { _, _ -> onSubmit() }
                 setNegativeButton(R.string.cancel) { _, _ -> }
-                setTitle(message)
+                setMessage(message)
             }
             builder.create()
         }

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordViewModel.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordViewModel.kt
@@ -1,6 +1,7 @@
 package com.foundy.presentation.view.keyword
 
 import androidx.lifecycle.*
+import com.foundy.domain.exception.NoSearchResultException
 import com.foundy.domain.model.Keyword
 import com.foundy.domain.usecase.firebase.IsSignedInUseCase
 import com.foundy.domain.usecase.firebase.SubscribeToUseCase
@@ -8,6 +9,7 @@ import com.foundy.domain.usecase.firebase.UnsubscribeFromUseCase
 import com.foundy.domain.usecase.keyword.AddKeywordUseCase
 import com.foundy.domain.usecase.keyword.ReadKeywordListUseCase
 import com.foundy.domain.usecase.keyword.RemoveKeywordUseCase
+import com.foundy.domain.usecase.notice.HasSearchResultUseCase
 import com.foundy.presentation.utils.KeywordValidator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -19,7 +21,8 @@ class KeywordViewModel @Inject constructor(
     private val removeKeywordUseCase: RemoveKeywordUseCase,
     private val subscribeToUseCase: SubscribeToUseCase,
     private val unsubscribeFromUseCase: UnsubscribeFromUseCase,
-    private val isSignedInUseCase: IsSignedInUseCase
+    private val isSignedInUseCase: IsSignedInUseCase,
+    private val hasSearchResultUseCase: HasSearchResultUseCase
 ) : ViewModel() {
 
     val keywordList = readKeywordListUseCase().asLiveData()
@@ -32,8 +35,8 @@ class KeywordViewModel @Inject constructor(
         removeKeywordUseCase(keyword)
     }
 
-    fun checkValid(keyword: String): Boolean {
-        return KeywordValidator(keyword, keywordList.value?.getOrNull() ?: emptyList())
+    fun checkValid(keyword: String) {
+        KeywordValidator.check(keyword, keywordList.value?.getOrNull() ?: emptyList())
     }
 
     fun subscribeTo(topic: String, onFailure: (Exception) -> Unit) {
@@ -45,4 +48,16 @@ class KeywordViewModel @Inject constructor(
     }
 
     fun isSignedIn() = isSignedInUseCase()
+
+    suspend fun checkKeywordHasSearchResult(keyword: String) {
+        val result = hasSearchResultUseCase(keyword)
+        if (result.isSuccess) {
+            val hasSearchResult = result.getOrNull()!!
+            if (!hasSearchResult) {
+                throw NoSearchResultException()
+            }
+        } else {
+            throw result.exceptionOrNull()!!
+        }
+    }
 }

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordViewModel.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordViewModel.kt
@@ -12,7 +12,12 @@ import com.foundy.domain.usecase.keyword.RemoveKeywordUseCase
 import com.foundy.domain.usecase.notice.HasSearchResultUseCase
 import com.foundy.presentation.utils.KeywordValidator
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import javax.inject.Inject
+import javax.inject.Named
 
 @HiltViewModel
 class KeywordViewModel @Inject constructor(
@@ -22,7 +27,8 @@ class KeywordViewModel @Inject constructor(
     private val subscribeToUseCase: SubscribeToUseCase,
     private val unsubscribeFromUseCase: UnsubscribeFromUseCase,
     private val isSignedInUseCase: IsSignedInUseCase,
-    private val hasSearchResultUseCase: HasSearchResultUseCase
+    private val hasSearchResultUseCase: HasSearchResultUseCase,
+    @Named("Main") private val dispatcher: CoroutineDispatcher = Dispatchers.Main
 ) : ViewModel() {
 
     val keywordList = readKeywordListUseCase().asLiveData()
@@ -35,10 +41,6 @@ class KeywordViewModel @Inject constructor(
         removeKeywordUseCase(keyword)
     }
 
-    fun checkValid(keyword: String) {
-        KeywordValidator.check(keyword, keywordList.value?.getOrNull() ?: emptyList())
-    }
-
     fun subscribeTo(topic: String, onFailure: (Exception) -> Unit) {
         subscribeToUseCase(topic, onFailure)
     }
@@ -49,7 +51,48 @@ class KeywordViewModel @Inject constructor(
 
     fun isSignedIn() = isSignedInUseCase()
 
-    suspend fun checkKeywordHasSearchResult(keyword: String) {
+    /**
+     * 키워드의 유효성 검사와 해당 키워드가 공지사항 검색결과에 존재하는지 확인한다.
+     *
+     * 검사에 성공한 경우 [onSuccess]가 호출되며, 실패한 경우 예외를 매개변수로하여 [onFailure]가 호출된다.
+     * 최종적으로 [onFinally]가 호출된다.
+     *
+     * 예외에는 다음 경우가 존재한다.
+     * - [KeywordValidator.KeywordInvalidException]: 유효성 검사에 실패한 경우
+     * - [NoSearchResultException]: 검색 결과가 없는 경우
+     * - [HttpException]: 검색에 실패한 경우
+     * - [Exception]: 그외에 경우
+     */
+    fun checkKeywordSubmit(
+        keyword: String,
+        onSuccess: () -> Unit,
+        onFailure: (e: Exception) -> Unit,
+        onFinally: () -> Unit
+    ) {
+        viewModelScope.launch(dispatcher) {
+            try {
+                checkValid(keyword)
+                checkKeywordHasSearchResult(keyword)
+
+                onSuccess()
+            } catch (e: Exception) {
+                onFailure(e)
+            } finally {
+                onFinally()
+            }
+        }
+    }
+
+    /**
+     * 키워드 문자의 유효성을 검사한다.
+     *
+     * 유효성 검사에 실패한 경우 [KeywordValidator.KeywordInvalidException]를 상속한 예외를 던진다.
+     */
+    fun checkValid(keyword: String) {
+        KeywordValidator.check(keyword, keywordList.value?.getOrNull() ?: emptyList())
+    }
+
+    private suspend fun checkKeywordHasSearchResult(keyword: String) {
         val result = hasSearchResultUseCase(keyword)
         if (result.isSuccess) {
             val hasSearchResult = result.getOrNull()!!

--- a/presentation/src/main/java/com/foundy/presentation/view/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/search/SearchViewModel.kt
@@ -19,8 +19,8 @@ class SearchViewModel @Inject constructor(
     private val addRecentQueryUseCase: AddRecentQueryUseCase,
     private val removeRecentQueryUseCase: RemoveRecentQueryUseCase,
     private val updateRecentQueryUseCase: UpdateRecentQueryUseCase,
-    @Named("RecentQuery")
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    @Named("Main")
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Main
 ) : ViewModel() {
 
     val recentQueries = getRecentQueryListUseCase().asLiveData().map { list ->

--- a/presentation/src/main/res/layout/fragment_keyword.xml
+++ b/presentation/src/main/res/layout/fragment_keyword.xml
@@ -8,7 +8,7 @@
     tools:context=".view.keyword.KeywordActivity">
 
     <ProgressBar
-        android:id="@+id/progressBar"
+        android:id="@+id/listProgressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -28,4 +28,6 @@
     <string name="invalid_keyword">유효하지 않은 키워드입니다.</string>
     <string name="add_keyword">키워드 추가하기</string>
     <string name="search_notification">공지사항 검색</string>
+    <string name="check_internet_connection">인터넷 연결을 확인해주세요.</string>
+    <string name="cannot_create_keyword">키워드를 생성할 수 없습니다.</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -30,4 +30,6 @@
     <string name="search_notification">공지사항 검색</string>
     <string name="check_internet_connection">인터넷 연결을 확인해주세요.</string>
     <string name="cannot_create_keyword">키워드를 생성할 수 없습니다.</string>
+    <string name="submit">등록</string>
+    <string name="cancel">취소</string>
 </resources>

--- a/presentation/src/test/java/com/foundy/presentation/KeywordValidatorTest.kt
+++ b/presentation/src/test/java/com/foundy/presentation/KeywordValidatorTest.kt
@@ -11,14 +11,14 @@ class KeywordValidatorTest {
     @Test
     fun `throws MinLengthException exception`() {
         assertThrows(KeywordValidator.MinLengthException::class.java) {
-            KeywordValidator("강", emptyList())
+            KeywordValidator.check("강", emptyList())
         }
     }
 
     @Test
     fun `throws AlreadyExistsException exception`() {
         assertThrows(KeywordValidator.AlreadyExistsException::class.java) {
-            KeywordValidator(
+            KeywordValidator.check(
                 "강하다",
                 listOf(Keyword("최고야"), Keyword("강하다"))
             )
@@ -28,26 +28,26 @@ class KeywordValidatorTest {
     @Test
     fun `throws InvalidCharacterException exception if keyword has blank`() {
         assertThrows(KeywordValidator.InvalidCharacterException::class.java) {
-            KeywordValidator(" 안녕", emptyList())
+            KeywordValidator.check(" 안녕", emptyList())
         }
     }
 
     @Test
     fun `throws InvalidCharacterException exception if keyword has English`() {
         assertThrows(KeywordValidator.InvalidCharacterException::class.java) {
-            KeywordValidator("wow", emptyList())
+            KeywordValidator.check("wow", emptyList())
         }
     }
 
     @Test
     fun `throws InvalidCharacterException exception if keyword has not completed Korean`() {
         assertThrows(KeywordValidator.InvalidCharacterException::class.java) {
-            KeywordValidator("단어ㅋ", emptyList())
+            KeywordValidator.check("단어ㅋ", emptyList())
         }
     }
 
     @Test
     fun `returns true if characters of keyword is valid`() {
-        assertTrue(KeywordValidator("안1녕2", emptyList()))
+        assertTrue(KeywordValidator.check("안1녕2", emptyList()))
     }
 }


### PR DESCRIPTION
Resolves #11 

- 공지사항 검색 결과가 없는 키워드를 추가할 때 경고하는 기능 추가
- `KeywordFragment`에서 텍스트 제출시 예외 처리 코드 향상 
- 모든 제출 버튼에 모두 debounce 적용 -> 한성대 사이트에 쿼리 과다하게 하지 않도록 하기 위함
- 검색중에는 제출 버튼이 `ProgressBar`로 변경됨