### PR TITLE
Refactor StateFlow

### DIFF
--- a/app/src/androidTest/java/com/foundy/hansungnotification/SearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/SearchViewModelTest.kt
@@ -12,6 +12,7 @@ import com.foundy.hansungnotification.fake.FakeNoticeRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeQueryRepositoryImpl
 import com.foundy.presentation.view.search.SearchViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -49,7 +50,7 @@ class SearchViewModelTest {
 
         // Create an empty collector for the StateFlow
         val collectJob = launch(testDispatcher) {
-            searchViewModel.recentQueries.collect {}
+            searchViewModel.recentQueries.collect()
         }
         assertEquals(0, searchViewModel.recentQueries.value.size)
 

--- a/app/src/androidTest/java/com/foundy/hansungnotification/fake/FakeAuthRepositoryImpl.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/fake/FakeAuthRepositoryImpl.kt
@@ -1,7 +1,5 @@
 package com.foundy.hansungnotification.fake
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import com.foundy.domain.repository.AuthRepository
 
 class FakeAuthRepositoryImpl(private var isSignedIn: Boolean = true) : AuthRepository {
@@ -14,7 +12,7 @@ class FakeAuthRepositoryImpl(private var isSignedIn: Boolean = true) : AuthRepos
         return isSignedIn
     }
 
-    override fun signInWith(idToken: String): LiveData<Result<Any>> {
-        return MutableLiveData()
+    override fun signInWith(idToken: String, onComplete: (result: Result<Any>) -> Unit) {
+
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         hilt_version = "2.42"
         mockk_version = "1.12.3" // 1.12.4 is Not working!
         fragment_version = "1.4.1"
-        life_cycle_version = "2.5.0"
+        life_cycle_version = "2.4.1" // 2.5.0 is NOT working on tests!
     }
     dependencies {
         // hilt

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ buildscript {
         hilt_version = "2.42"
         mockk_version = "1.12.3" // 1.12.4 is Not working!
         fragment_version = "1.4.1"
+        life_cycle_version = "2.5.0"
     }
     dependencies {
         // hilt

--- a/data/src/main/java/com/foundy/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/foundy/data/repository/AuthRepositoryImpl.kt
@@ -1,7 +1,5 @@
 package com.foundy.data.repository
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
 import com.foundy.domain.repository.AuthRepository
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.ktx.auth
@@ -13,16 +11,14 @@ class AuthRepositoryImpl : AuthRepository {
         return Firebase.auth.currentUser != null
     }
 
-    override fun signInWith(idToken: String): LiveData<Result<Any>> {
-        val result = MutableLiveData<Result<Any>>()
+    override fun signInWith(idToken: String, onComplete: (result: Result<Any>) -> Unit) {
         val firebaseCredential = GoogleAuthProvider.getCredential(idToken, null)
         Firebase.auth.signInWithCredential(firebaseCredential).addOnCompleteListener { task ->
             if (task.isSuccessful) {
-                result.value = Result.success(true)
+                onComplete(Result.success(true))
             } else {
-                result.value = Result.failure(task.exception!!)
+                onComplete(Result.failure(task.exception!!))
             }
         }
-        return result
     }
 }

--- a/domain/src/main/java/com/foundy/domain/repository/AuthRepository.kt
+++ b/domain/src/main/java/com/foundy/domain/repository/AuthRepository.kt
@@ -1,8 +1,6 @@
 package com.foundy.domain.repository
 
-import androidx.lifecycle.LiveData
-
 interface AuthRepository {
     fun isSignedIn(): Boolean
-    fun signInWith(idToken: String): LiveData<Result<Any>>
+    fun signInWith(idToken: String, onComplete: (result: Result<Any>) -> Unit)
 }

--- a/domain/src/main/java/com/foundy/domain/usecase/auth/SignInWithUseCase.kt
+++ b/domain/src/main/java/com/foundy/domain/usecase/auth/SignInWithUseCase.kt
@@ -6,5 +6,7 @@ import javax.inject.Inject
 class SignInWithUseCase @Inject constructor(
     private val repository: AuthRepository
 ) {
-    operator fun invoke(idToken: String) = repository.signInWith(idToken)
+    operator fun invoke(idToken: String, onComplete: (result: Result<Any>) -> Unit) {
+        repository.signInWith(idToken, onComplete)
+    }
 }

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -21,7 +21,8 @@ dependencies {
     androidTestAnnotationProcessor "com.google.dagger:hilt-android-compiler:$hilt_version"
 
     // Coroutine
-    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.4.1"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$life_cycle_version"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$life_cycle_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutine_version"
 
     // fragment

--- a/presentation/src/main/java/com/foundy/presentation/view/home/favorite/FavoriteFragment.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/home/favorite/FavoriteFragment.kt
@@ -6,14 +6,15 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.foundy.presentation.view.home.HomeViewModel
 import com.foundy.presentation.R
 import com.foundy.presentation.databinding.FragmentFavoriteBinding
 import com.foundy.presentation.extension.addDividerDecoration
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 class FavoriteFragment(
@@ -34,9 +35,11 @@ class FavoriteFragment(
             recyclerView.layoutManager = LinearLayoutManager(context)
 
             viewLifecycleOwner.lifecycleScope.launch {
-                viewModel.favoritesState.collect {
-                    emptyText.isVisible = it.isEmpty()
-                    adapter.submitList(it)
+                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    viewModel.favoritesState.collect {
+                        emptyText.isVisible = it.isEmpty()
+                        adapter.submitList(it)
+                    }
                 }
             }
         }

--- a/presentation/src/main/java/com/foundy/presentation/view/home/favorite/FavoriteFragment.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/home/favorite/FavoriteFragment.kt
@@ -15,6 +15,7 @@ import com.foundy.presentation.view.home.HomeViewModel
 import com.foundy.presentation.R
 import com.foundy.presentation.databinding.FragmentFavoriteBinding
 import com.foundy.presentation.extension.addDividerDecoration
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 class FavoriteFragment(

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
@@ -28,6 +28,7 @@ import com.foundy.presentation.extension.setOnEditorActionListenerWithDebounce
 import com.foundy.presentation.utils.KeywordValidator
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputLayout
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
@@ -81,7 +81,7 @@ class KeywordFragment(
             recyclerView.layoutManager = LinearLayoutManager(requireContext())
 
             viewLifecycleOwner.lifecycleScope.launch {
-                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                     viewModel.keywordListState.collect { result ->
                         listProgressBar.isVisible = false
                         if (result.isSuccess) {

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
@@ -12,8 +12,10 @@ import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.foundy.domain.exception.NoSearchResultException
 import com.foundy.domain.model.Keyword
@@ -26,6 +28,7 @@ import com.foundy.presentation.extension.setOnEditorActionListenerWithDebounce
 import com.foundy.presentation.utils.KeywordValidator
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputLayout
+import kotlinx.coroutines.launch
 import retrofit2.HttpException
 
 class KeywordFragment(
@@ -77,21 +80,25 @@ class KeywordFragment(
             recyclerView.addDividerDecoration(horizontalPaddingDimen = R.dimen.keyword_divider_horizontal_padding)
             recyclerView.layoutManager = LinearLayoutManager(requireContext())
 
-            viewModel.keywordList.observe(viewLifecycleOwner) { result ->
-                listProgressBar.isVisible = false
-                if (result.isSuccess) {
-                    val keywords = result.getOrNull()!!
-                    adapter.submitList(keywords)
-                    if (keywords.size >= MAX_KEYWORD_COUNT) {
-                        disableTextInput(binding)
-                    } else {
-                        enableTextInput(binding)
+            viewLifecycleOwner.lifecycleScope.launch {
+                repeatOnLifecycle(Lifecycle.State.STARTED) {
+                    viewModel.keywordListState.collect { result ->
+                        listProgressBar.isVisible = false
+                        if (result.isSuccess) {
+                            val keywords = result.getOrNull()!!
+                            adapter.submitList(keywords)
+                            if (keywords.size >= MAX_KEYWORD_COUNT) {
+                                disableTextInput(binding)
+                            } else {
+                                enableTextInput(binding)
+                            }
+                        } else {
+                            errorMsg.isVisible = true
+                            textInputLayout.isVisible = false
+                            keywordHelpText.isVisible = false
+                            Log.e(TAG, "Failed to load keywords: ${result.exceptionOrNull()}")
+                        }
                     }
-                } else {
-                    errorMsg.isVisible = true
-                    textInputLayout.isVisible = false
-                    keywordHelpText.isVisible = false
-                    Log.e(TAG, "Failed to load keywords: ${result.exceptionOrNull()}")
                 }
             }
         }

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/LoginFragment.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/LoginFragment.kt
@@ -40,10 +40,7 @@ class LoginFragment : Fragment(R.layout.fragment_login) {
                 val task = GoogleSignIn.getSignedInAccountFromIntent(it.data)
                 try {
                     val account = task.getResult(ApiException::class.java)
-                    viewModel.signInWith(account.idToken!!).observe(
-                        viewLifecycleOwner,
-                        ::onCompleteSignIn
-                    )
+                    viewModel.signInWith(account.idToken!!, ::onCompleteSignIn)
                     Log.d(TAG, "Success google sign in: " + account.id)
                 } catch (e: ApiException) {
                     showSnackBar(getString(R.string.failed_to_sign_in))

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/LoginViewModel.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/LoginViewModel.kt
@@ -12,7 +12,9 @@ class LoginViewModel @Inject constructor(
     private val subscribeAllDbKeywordsUseCase: SubscribeAllDbKeywordsUseCase
 ) : ViewModel() {
 
-    fun signInWith(idToken: String) = signInWithUseCase(idToken)
+    fun signInWith(idToken: String, onComplete: (result: Result<Any>) -> Unit) {
+        signInWithUseCase(idToken, onComplete)
+    }
 
     fun subscribeAllDbKeywords() = subscribeAllDbKeywordsUseCase()
 }

--- a/presentation/src/main/java/com/foundy/presentation/view/search/SearchActivity.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/search/SearchActivity.kt
@@ -6,7 +6,9 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -59,9 +61,13 @@ class SearchActivity : AppCompatActivity() {
     private fun initSearchView(adapter: NoticeAdapter) = with(binding.searchView) {
         expand(true)
 
-        viewModel.recentQueries.observe(this@SearchActivity) {
-            val recentList = SuggestionCreationUtil.asRecentSearchSuggestions(it)
-            setSuggestions(recentList, false)
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.recentQueries.collect {
+                    val recentList = SuggestionCreationUtil.asRecentSearchSuggestions(it)
+                    setSuggestions(recentList, false)
+                }
+            }
         }
         setOnSearchConfirmedListener { searchView, query ->
             searchView.collapse()

--- a/presentation/src/main/java/com/foundy/presentation/view/search/SearchActivity.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/search/SearchActivity.kt
@@ -21,6 +21,7 @@ import com.paulrybitskyi.persistentsearchview.listeners.OnSuggestionChangeListen
 import com.paulrybitskyi.persistentsearchview.utils.SuggestionCreationUtil
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 


### PR DESCRIPTION
- `LiveData`에서 `StateFlow`로 이전
  -> Domain 모듈에서 `LiveData`를 사용하지 않도록 수정(플랫폼과 상관없이 작성하도록 하기 위함)
- UI에서 lifecycle 관련하여 잘못 사용하던 `StateFlow` 코드 수정

많은 Flow 관련 자료를 찾아보았는데 `FavoriteDelegate` 구현이 옳은지 아직 의문이다. 