### PR TITLE
Favorite StateFlow를 Repository로 이동

### DIFF
--- a/app/src/androidTest/java/com/foundy/hansungnotification/FavoriteFragmentTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/FavoriteFragmentTest.kt
@@ -11,11 +11,12 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry
+import com.foundy.domain.usecase.favorite.ReadFavoriteListUseCase
 import com.foundy.domain.usecase.messaging.SubscribeAllDbKeywordsUseCase
 import com.foundy.domain.usecase.notice.GetNoticeListUseCase
 import com.foundy.hansungnotification.factory.NoticeFactory
 import com.foundy.hansungnotification.factory.NoticeType
-import com.foundy.hansungnotification.fake.FakeFavoriteViewModelDelegateFactory
+import com.foundy.hansungnotification.fake.FakeNoticeUiStateCreatorFactory
 import com.foundy.hansungnotification.fake.FakeFavoriteRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeMessagingRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeNoticeRepositoryImpl
@@ -64,8 +65,9 @@ class FavoriteFragmentTest {
     @BindValue
     val viewModel = HomeViewModel(
         GetNoticeListUseCase(fakeNoticeRepository),
+        ReadFavoriteListUseCase(fakeFavoriteRepository),
         SubscribeAllDbKeywordsUseCase(fakeMessagingRepository),
-        FakeFavoriteViewModelDelegateFactory(fakeFavoriteRepository)
+        FakeNoticeUiStateCreatorFactory(fakeFavoriteRepository)
     )
 
     lateinit var context: Context
@@ -90,8 +92,7 @@ class FavoriteFragmentTest {
             themeResId = R.style.Theme_HansungNotification
         )
 
-        fakeFavoriteRepository.setFakeList(mockNotices)
-        fakeFavoriteRepository.emitFake()
+        fakeFavoriteRepository.emit(mockNotices)
 
         waitForView(withId(R.id.recyclerView)).check { view, noViewFoundException ->
             if (noViewFoundException != null) {
@@ -113,7 +114,6 @@ class FavoriteFragmentTest {
             val recyclerView = view as RecyclerView
             val expectedSize = mockNotices.size - 1
             assertEquals(expectedSize, recyclerView.adapter?.itemCount)
-            assertEquals(expectedSize, viewModel.favoritesState.value.size)
         }
     }
 

--- a/app/src/androidTest/java/com/foundy/hansungnotification/KeywordActivityTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/KeywordActivityTest.kt
@@ -8,6 +8,7 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry
 import com.foundy.domain.usecase.auth.IsSignedInUseCase
+import com.foundy.domain.usecase.favorite.ReadFavoriteListUseCase
 import com.foundy.domain.usecase.messaging.SubscribeToUseCase
 import com.foundy.domain.usecase.messaging.UnsubscribeFromUseCase
 import com.foundy.domain.usecase.keyword.AddKeywordUseCase
@@ -51,8 +52,9 @@ class KeywordActivityTest {
     @BindValue
     val homeViewModel = HomeViewModel(
         GetNoticeListUseCase(fakeNoticeRepository),
+        ReadFavoriteListUseCase(fakeFavoriteRepository),
         SubscribeAllDbKeywordsUseCase(fakeMessagingRepository),
-        FakeFavoriteViewModelDelegateFactory(fakeFavoriteRepository)
+        FakeNoticeUiStateCreatorFactory(fakeFavoriteRepository)
     )
 
     @BindValue

--- a/app/src/androidTest/java/com/foundy/hansungnotification/NoticeFragmentTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/NoticeFragmentTest.kt
@@ -7,11 +7,12 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.platform.app.InstrumentationRegistry
+import com.foundy.domain.usecase.favorite.ReadFavoriteListUseCase
 import com.foundy.domain.usecase.messaging.SubscribeAllDbKeywordsUseCase
 import com.foundy.domain.usecase.notice.GetNoticeListUseCase
 import com.foundy.hansungnotification.factory.NoticeFactory
 import com.foundy.hansungnotification.factory.NoticeType
-import com.foundy.hansungnotification.fake.FakeFavoriteViewModelDelegateFactory
+import com.foundy.hansungnotification.fake.FakeNoticeUiStateCreatorFactory
 import com.foundy.hansungnotification.fake.FakeFavoriteRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeMessagingRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeNoticeRepositoryImpl
@@ -53,8 +54,9 @@ class NoticeFragmentTest {
     @BindValue
     val viewModel = HomeViewModel(
         GetNoticeListUseCase(fakeNoticeRepository),
+        ReadFavoriteListUseCase(fakeFavoriteRepository),
         SubscribeAllDbKeywordsUseCase(fakeMessagingRepository),
-        FakeFavoriteViewModelDelegateFactory(fakeFavoriteRepository)
+        FakeNoticeUiStateCreatorFactory(fakeFavoriteRepository)
     )
 
     lateinit var context: Context

--- a/app/src/androidTest/java/com/foundy/hansungnotification/SearchViewModelTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/SearchViewModelTest.kt
@@ -6,7 +6,7 @@ import com.foundy.domain.usecase.query.AddRecentQueryUseCase
 import com.foundy.domain.usecase.query.GetRecentQueryListUseCase
 import com.foundy.domain.usecase.query.RemoveRecentQueryUseCase
 import com.foundy.domain.usecase.query.UpdateRecentQueryUseCase
-import com.foundy.hansungnotification.fake.FakeFavoriteViewModelDelegateFactory
+import com.foundy.hansungnotification.fake.FakeNoticeUiStateCreatorFactory
 import com.foundy.hansungnotification.fake.FakeFavoriteRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeNoticeRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeQueryRepositoryImpl
@@ -39,7 +39,7 @@ class SearchViewModelTest {
         RemoveRecentQueryUseCase(fakeQueryRepository),
         UpdateRecentQueryUseCase(fakeQueryRepository),
         SearchNoticeListUseCase(fakeNoticeRepository),
-        FakeFavoriteViewModelDelegateFactory(fakeFavoriteRepository),
+        FakeNoticeUiStateCreatorFactory(fakeFavoriteRepository),
         dispatcher = testDispatcher
     )
 

--- a/app/src/androidTest/java/com/foundy/hansungnotification/fake/FakeFavoriteRepositoryImpl.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/fake/FakeFavoriteRepositoryImpl.kt
@@ -3,31 +3,31 @@ package com.foundy.hansungnotification.fake
 import com.foundy.domain.model.Notice
 import com.foundy.domain.repository.FavoriteRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 
 class FakeFavoriteRepositoryImpl: FavoriteRepository {
 
-    private val sharedFlow = MutableSharedFlow<List<Notice>>()
-    private val noticeList = mutableListOf<Notice>()
+    private val stateFlow = MutableStateFlow<List<Notice>>(emptyList())
 
-    fun setFakeList(notices: List<Notice>) {
-        noticeList.clear()
-        noticeList.addAll(notices)
+    suspend fun emit(notices: List<Notice>) {
+        stateFlow.emit(notices)
     }
 
-    suspend fun emitFake() {
-        sharedFlow.emit(noticeList)
-    }
+    override fun getAll(): Flow<List<Notice>> = stateFlow
 
-    override fun getAll(): Flow<List<Notice>> = sharedFlow
+    override fun isFavorite(notice: Notice): Boolean {
+        return stateFlow.value.any { it.url == notice.url }
+    }
 
     override suspend fun add(notice: Notice) {
-        noticeList.add(notice)
-        emitFake()
+        val newList = mutableListOf(*stateFlow.value.toTypedArray())
+        newList.add(notice)
+        emit(newList)
     }
 
     override suspend fun remove(notice: Notice) {
-        noticeList.remove(notice)
-        emitFake()
+        val newList = mutableListOf(*stateFlow.value.toTypedArray())
+        newList.remove(notice)
+        emit(newList)
     }
 }

--- a/app/src/androidTest/java/com/foundy/hansungnotification/fake/FakeNoticeUiStateCreatorFactory.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/fake/FakeNoticeUiStateCreatorFactory.kt
@@ -17,7 +17,7 @@ class FakeNoticeUiStateCreatorFactory(
     override fun create(
         viewModelScope: CoroutineScope,
         dispatcher: CoroutineDispatcher,
-        enableCollect: Boolean
+        triggerCollection: Boolean
     ) = NoticeUiStateCreator(
         ReadFavoriteListUseCase(favoriteRepository),
         AddFavoriteNoticeUseCase(favoriteRepository),
@@ -25,6 +25,6 @@ class FakeNoticeUiStateCreatorFactory(
         IsFavoriteNoticeUseCase(favoriteRepository),
         viewModelScope,
         dispatcher,
-        enableCollect = true,
+        triggerCollection = true,
     )
 }

--- a/app/src/androidTest/java/com/foundy/hansungnotification/fake/FakeNoticeUiStateCreatorFactory.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/fake/FakeNoticeUiStateCreatorFactory.kt
@@ -2,25 +2,29 @@ package com.foundy.hansungnotification.fake
 
 import com.foundy.domain.repository.FavoriteRepository
 import com.foundy.domain.usecase.favorite.AddFavoriteNoticeUseCase
+import com.foundy.domain.usecase.favorite.IsFavoriteNoticeUseCase
 import com.foundy.domain.usecase.favorite.ReadFavoriteListUseCase
 import com.foundy.domain.usecase.favorite.RemoveFavoriteNoticeUseCase
-import com.foundy.presentation.view.common.FavoriteViewModelDelegate
-import com.foundy.presentation.view.common.FavoriteViewModelDelegateFactory
+import com.foundy.presentation.view.common.NoticeUiStateCreator
+import com.foundy.presentation.view.common.NoticeUiStateCreatorFactory
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 
-class FakeFavoriteViewModelDelegateFactory(
+class FakeNoticeUiStateCreatorFactory(
     private val favoriteRepository: FavoriteRepository
-) : FavoriteViewModelDelegateFactory {
+) : NoticeUiStateCreatorFactory {
 
     override fun create(
         viewModelScope: CoroutineScope,
-        dispatcher: CoroutineDispatcher
-    ) = FavoriteViewModelDelegate(
+        dispatcher: CoroutineDispatcher,
+        enableCollect: Boolean
+    ) = NoticeUiStateCreator(
         ReadFavoriteListUseCase(favoriteRepository),
         AddFavoriteNoticeUseCase(favoriteRepository),
         RemoveFavoriteNoticeUseCase(favoriteRepository),
+        IsFavoriteNoticeUseCase(favoriteRepository),
         viewModelScope,
-        dispatcher
+        dispatcher,
+        enableCollect = true,
     )
 }

--- a/domain/src/main/java/com/foundy/domain/repository/FavoriteRepository.kt
+++ b/domain/src/main/java/com/foundy/domain/repository/FavoriteRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface FavoriteRepository {
     fun getAll(): Flow<List<Notice>>
+    fun isFavorite(notice: Notice) : Boolean
     suspend fun add(notice: Notice)
     suspend fun remove(notice: Notice)
 }

--- a/domain/src/main/java/com/foundy/domain/usecase/favorite/IsFavoriteNoticeUseCase.kt
+++ b/domain/src/main/java/com/foundy/domain/usecase/favorite/IsFavoriteNoticeUseCase.kt
@@ -1,0 +1,11 @@
+package com.foundy.domain.usecase.favorite
+
+import com.foundy.domain.model.Notice
+import com.foundy.domain.repository.FavoriteRepository
+import javax.inject.Inject
+
+class IsFavoriteNoticeUseCase @Inject constructor(
+    private val repository: FavoriteRepository
+) {
+    operator fun invoke(notice: Notice) = repository.isFavorite(notice)
+}

--- a/presentation/src/main/java/com/foundy/presentation/view/common/NoticeUiStateCreator.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/common/NoticeUiStateCreator.kt
@@ -20,7 +20,7 @@ interface NoticeUiStateCreatorFactory {
     fun create(
         viewModelScope: CoroutineScope,
         dispatcher: CoroutineDispatcher = Dispatchers.Main,
-        enableCollect: Boolean = true
+        triggerCollection: Boolean = true
     ): NoticeUiStateCreator
 }
 
@@ -31,11 +31,11 @@ class NoticeUiStateCreator @AssistedInject constructor(
     private val isFavoriteNoticeUseCase: IsFavoriteNoticeUseCase,
     @Assisted private val viewModelScope: CoroutineScope,
     @Assisted private val dispatcher: CoroutineDispatcher = Dispatchers.Main,
-    @Assisted enableCollect: Boolean
+    @Assisted triggerCollection: Boolean
 ) {
 
     init {
-        if (enableCollect) {
+        if (triggerCollection) {
             viewModelScope.launch(dispatcher) {
                 readFavoriteListUseCase().collect()
             }

--- a/presentation/src/main/java/com/foundy/presentation/view/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/home/HomeViewModel.kt
@@ -4,9 +4,10 @@ import androidx.lifecycle.*
 import androidx.paging.cachedIn
 import androidx.paging.map
 import com.foundy.domain.exception.NotSignedInException
+import com.foundy.domain.usecase.favorite.ReadFavoriteListUseCase
 import com.foundy.domain.usecase.notice.GetNoticeListUseCase
 import com.foundy.domain.usecase.messaging.SubscribeAllDbKeywordsUseCase
-import com.foundy.presentation.view.common.FavoriteViewModelDelegateFactory
+import com.foundy.presentation.view.common.NoticeUiStateCreatorFactory
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import javax.inject.Inject
@@ -14,16 +15,19 @@ import javax.inject.Inject
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     getNoticeListUseCase: GetNoticeListUseCase,
+    readFavoriteListUseCase: ReadFavoriteListUseCase,
     private val subscribeAllDbKeywordsUseCase: SubscribeAllDbKeywordsUseCase,
-    favoriteDelegateFactory: FavoriteViewModelDelegateFactory
+    noticeUiStateCreatorFactory: NoticeUiStateCreatorFactory
 ) : ViewModel() {
 
-    private val favoritesDelegate = favoriteDelegateFactory.create(viewModelScope)
+    private val noticeUiStateCreator = noticeUiStateCreatorFactory.create(viewModelScope)
 
-    val favoritesState get() = favoritesDelegate.favoritesState
+    val favoritesState = readFavoriteListUseCase().map { list ->
+        list.map(noticeUiStateCreator::create)
+    }
 
     val noticeFlow = getNoticeListUseCase().cachedIn(viewModelScope).map { pagingData ->
-        pagingData.map { favoritesDelegate.createNoticeUiState(it) }
+        pagingData.map(noticeUiStateCreator::create)
     }
 
     fun subscribeAllDbKeywords() {

--- a/presentation/src/main/java/com/foundy/presentation/view/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/search/SearchViewModel.kt
@@ -11,7 +11,7 @@ import com.foundy.domain.usecase.query.GetRecentQueryListUseCase
 import com.foundy.domain.usecase.query.RemoveRecentQueryUseCase
 import com.foundy.domain.usecase.query.UpdateRecentQueryUseCase
 import com.foundy.presentation.model.NoticeUiState
-import com.foundy.presentation.view.common.FavoriteViewModelDelegateFactory
+import com.foundy.presentation.view.common.NoticeUiStateCreatorFactory
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -27,11 +27,11 @@ class SearchViewModel @Inject constructor(
     private val removeRecentQueryUseCase: RemoveRecentQueryUseCase,
     private val updateRecentQueryUseCase: UpdateRecentQueryUseCase,
     private val searchNoticeListUseCase: SearchNoticeListUseCase,
-    favoriteDelegateFactory: FavoriteViewModelDelegateFactory,
+    noticeUiStateCreatorFactory: NoticeUiStateCreatorFactory,
     @Named("Main") private val dispatcher: CoroutineDispatcher = Dispatchers.Main
 ) : ViewModel() {
 
-    private val favoriteDelegate = favoriteDelegateFactory.create(viewModelScope, dispatcher)
+    private val noticeUiStateCreator = noticeUiStateCreatorFactory.create(viewModelScope, dispatcher)
 
     val recentQueries = getRecentQueryListUseCase().map { list ->
         list.map { it.content }
@@ -62,7 +62,7 @@ class SearchViewModel @Inject constructor(
 
     fun searchNotices(query: String): Flow<PagingData<NoticeUiState>> {
         return searchNoticeListUseCase(query).cachedIn(viewModelScope).map { pagingData ->
-            pagingData.map { favoriteDelegate.createNoticeUiState(it) }
+            pagingData.map(noticeUiStateCreator::create)
         }
     }
 }


### PR DESCRIPTION
- 기존 `ViewModel`마다 존재하던 `StateFlow`들을 `FavoriteRepository`로 이동하여 하나를 공유하도록 했다. 이로써 데이터베이스 접근이 줄어들 것이다. 하지만 싱글톤으로 계속해서 `StateFlow`를 유지하는 것이 괜찮은지는 확인해봐야한다. `WhileSubscribed`를 이용하기 때문에 구독자가 없어지면 공유를 중단해서 괜찮을 것 같기도 하다.
- 또한 `NoticeUiStateCreator`로 클래스 이름을 수정했다.