### PR TITLE
동일한 계정을 사용하는 다른 기기에서 키워드를 삭제한 경우 알림 안띄우도록 수정

### DIFF
--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     // firebase
     implementation 'com.google.firebase:firebase-messaging-ktx:23.0.6'
     implementation 'com.google.android.gms:play-services-auth:20.2.0'
+    implementation 'com.google.firebase:firebase-database-ktx:20.0.5'
+    implementation 'com.google.firebase:firebase-auth-ktx:21.0.6'
 
     // mockk
     testImplementation "io.mockk:mockk:$mockk_version"


### PR DESCRIPTION
Fixes #24

시나리오는 다음과 같다.
1. 서버에서 메시징 전송
2. 기기에서 메시지 수신
3. DB에 키워드가 존재하는지 확인
- 3에서 존재한다면 알림을 띄운다.
- 3에서 **키워드가 DB에 없다면 구독을 취소**한다.