### PR TITLE
키워드를 얻는 함수에서 `callbackFlow`를 잘못사용하여 발생한 충돌 제거

### DIFF
--- a/app/src/androidTest/java/com/foundy/hansungnotification/KeywordActivityTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/KeywordActivityTest.kt
@@ -8,17 +8,11 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry
 import com.foundy.domain.usecase.auth.IsSignedInUseCase
-import com.foundy.domain.usecase.messaging.SubscribeToUseCase
-import com.foundy.domain.usecase.messaging.UnsubscribeFromUseCase
-import com.foundy.domain.usecase.keyword.AddKeywordUseCase
-import com.foundy.domain.usecase.keyword.ReadKeywordListUseCase
-import com.foundy.domain.usecase.keyword.RemoveKeywordUseCase
-import com.foundy.domain.usecase.notice.HasSearchResultUseCase
 import com.foundy.hansungnotification.fake.*
 import com.foundy.hansungnotification.utils.RetryTestRule
 import com.foundy.presentation.R
 import com.foundy.presentation.view.keyword.KeywordActivity
-import com.foundy.presentation.view.keyword.KeywordViewModel
+import com.foundy.presentation.view.keyword.KeywordActivityViewModel
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -39,20 +33,11 @@ class KeywordActivityTest {
     @JvmField
     val retryRule = RetryTestRule()
 
-    private val fakeKeywordRepository = FakeKeywordRepositoryImpl()
-    private val fakeMessagingRepository = FakeMessagingRepositoryImpl()
     private val fakeAuthRepository = FakeAuthRepositoryImpl()
-    private val fakeNoticeRepository = FakeNoticeRepositoryImpl()
 
     @BindValue
-    val keywordViewModel = KeywordViewModel(
-        ReadKeywordListUseCase(fakeKeywordRepository),
-        AddKeywordUseCase(fakeKeywordRepository),
-        RemoveKeywordUseCase(fakeKeywordRepository),
-        SubscribeToUseCase(fakeMessagingRepository),
-        UnsubscribeFromUseCase(fakeMessagingRepository),
+    val keywordActivityViewModel = KeywordActivityViewModel(
         IsSignedInUseCase(fakeAuthRepository),
-        HasSearchResultUseCase(fakeNoticeRepository)
     )
 
     lateinit var context: Context

--- a/app/src/androidTest/java/com/foundy/hansungnotification/KeywordActivityTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/KeywordActivityTest.kt
@@ -8,11 +8,18 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry
 import com.foundy.domain.usecase.auth.IsSignedInUseCase
+import com.foundy.domain.usecase.keyword.AddKeywordUseCase
+import com.foundy.domain.usecase.keyword.ReadKeywordListUseCase
+import com.foundy.domain.usecase.keyword.RemoveKeywordUseCase
+import com.foundy.domain.usecase.messaging.SubscribeToUseCase
+import com.foundy.domain.usecase.messaging.UnsubscribeFromUseCase
+import com.foundy.domain.usecase.notice.HasSearchResultUseCase
 import com.foundy.hansungnotification.fake.*
 import com.foundy.hansungnotification.utils.RetryTestRule
 import com.foundy.presentation.R
 import com.foundy.presentation.view.keyword.KeywordActivity
 import com.foundy.presentation.view.keyword.KeywordActivityViewModel
+import com.foundy.presentation.view.keyword.KeywordFragmentViewModel
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -34,10 +41,23 @@ class KeywordActivityTest {
     val retryRule = RetryTestRule()
 
     private val fakeAuthRepository = FakeAuthRepositoryImpl()
+    private val fakeKeywordRepository = FakeKeywordRepositoryImpl()
+    private val fakeMessagingRepository = FakeMessagingRepositoryImpl()
+    private val fakeNoticeRepository = FakeNoticeRepositoryImpl()
 
     @BindValue
     val keywordActivityViewModel = KeywordActivityViewModel(
         IsSignedInUseCase(fakeAuthRepository),
+    )
+
+    @BindValue
+    val keywordFragmentViewModel = KeywordFragmentViewModel(
+        ReadKeywordListUseCase(fakeKeywordRepository),
+        AddKeywordUseCase(fakeKeywordRepository),
+        RemoveKeywordUseCase(fakeKeywordRepository),
+        SubscribeToUseCase(fakeMessagingRepository),
+        UnsubscribeFromUseCase(fakeMessagingRepository),
+        HasSearchResultUseCase(fakeNoticeRepository)
     )
 
     lateinit var context: Context

--- a/app/src/androidTest/java/com/foundy/hansungnotification/KeywordFragmentTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/KeywordFragmentTest.kt
@@ -11,12 +11,14 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.foundy.domain.model.Keyword
+import com.foundy.domain.usecase.auth.IsSignedInUseCase
 import com.foundy.domain.usecase.messaging.SubscribeToUseCase
 import com.foundy.domain.usecase.messaging.UnsubscribeFromUseCase
 import com.foundy.domain.usecase.keyword.AddKeywordUseCase
 import com.foundy.domain.usecase.keyword.ReadKeywordListUseCase
 import com.foundy.domain.usecase.keyword.RemoveKeywordUseCase
 import com.foundy.domain.usecase.notice.HasSearchResultUseCase
+import com.foundy.hansungnotification.fake.FakeAuthRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeKeywordRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeMessagingRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeNoticeRepositoryImpl
@@ -25,6 +27,7 @@ import com.foundy.hansungnotification.utils.withIndex
 import com.foundy.presentation.R
 import com.foundy.presentation.utils.KeywordValidator
 import com.foundy.presentation.view.keyword.KeywordActivity
+import com.foundy.presentation.view.keyword.KeywordActivityViewModel
 import com.foundy.presentation.view.keyword.KeywordFragment
 import com.foundy.presentation.view.keyword.KeywordFragmentViewModel
 import com.google.android.material.textfield.TextInputEditText
@@ -60,6 +63,7 @@ class KeywordFragmentTest {
     private val fakeKeywordRepository = FakeKeywordRepositoryImpl()
     private val fakeMessagingRepository = FakeMessagingRepositoryImpl()
     private val fakeNoticeRepository = FakeNoticeRepositoryImpl()
+    private val fakeAuthRepository = FakeAuthRepositoryImpl()
 
     @BindValue
     val viewModel = KeywordFragmentViewModel(
@@ -70,6 +74,11 @@ class KeywordFragmentTest {
         UnsubscribeFromUseCase(fakeMessagingRepository),
         HasSearchResultUseCase(fakeNoticeRepository),
         dispatcher
+    )
+
+    @BindValue
+    val keywordActivityViewModel = KeywordActivityViewModel(
+        IsSignedInUseCase(fakeAuthRepository),
     )
 
     private lateinit var context: Context

--- a/app/src/androidTest/java/com/foundy/hansungnotification/KeywordFragmentTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/KeywordFragmentTest.kt
@@ -11,14 +11,12 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.foundy.domain.model.Keyword
-import com.foundy.domain.usecase.auth.IsSignedInUseCase
 import com.foundy.domain.usecase.messaging.SubscribeToUseCase
 import com.foundy.domain.usecase.messaging.UnsubscribeFromUseCase
 import com.foundy.domain.usecase.keyword.AddKeywordUseCase
 import com.foundy.domain.usecase.keyword.ReadKeywordListUseCase
 import com.foundy.domain.usecase.keyword.RemoveKeywordUseCase
 import com.foundy.domain.usecase.notice.HasSearchResultUseCase
-import com.foundy.hansungnotification.fake.FakeAuthRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeKeywordRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeMessagingRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeNoticeRepositoryImpl
@@ -28,7 +26,7 @@ import com.foundy.presentation.R
 import com.foundy.presentation.utils.KeywordValidator
 import com.foundy.presentation.view.keyword.KeywordActivity
 import com.foundy.presentation.view.keyword.KeywordFragment
-import com.foundy.presentation.view.keyword.KeywordViewModel
+import com.foundy.presentation.view.keyword.KeywordFragmentViewModel
 import com.google.android.material.textfield.TextInputEditText
 import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -61,17 +59,15 @@ class KeywordFragmentTest {
 
     private val fakeKeywordRepository = FakeKeywordRepositoryImpl()
     private val fakeMessagingRepository = FakeMessagingRepositoryImpl()
-    private val fakeAuthRepository = FakeAuthRepositoryImpl()
     private val fakeNoticeRepository = FakeNoticeRepositoryImpl()
 
     @BindValue
-    val keywordViewModel = KeywordViewModel(
+    val viewModel = KeywordFragmentViewModel(
         ReadKeywordListUseCase(fakeKeywordRepository),
         AddKeywordUseCase(fakeKeywordRepository),
         RemoveKeywordUseCase(fakeKeywordRepository),
         SubscribeToUseCase(fakeMessagingRepository),
         UnsubscribeFromUseCase(fakeMessagingRepository),
-        IsSignedInUseCase(fakeAuthRepository),
         HasSearchResultUseCase(fakeNoticeRepository),
         dispatcher
     )
@@ -84,7 +80,7 @@ class KeywordFragmentTest {
         context = InstrumentationRegistry.getInstrumentation().targetContext
 
         with(mockk<ViewModelProvider.Factory>()) {
-            every { create(keywordViewModel::class.java) } answers { keywordViewModel }
+            every { create(KeywordFragmentViewModel::class.java) } answers { viewModel }
             every { fragmentFactory.instantiate(any(), any()) } answers {
                 KeywordFragment { this@with }
             }

--- a/app/src/androidTest/java/com/foundy/hansungnotification/KeywordFragmentViewModelTest.kt
+++ b/app/src/androidTest/java/com/foundy/hansungnotification/KeywordFragmentViewModelTest.kt
@@ -1,19 +1,17 @@
 package com.foundy.hansungnotification
 
 import com.foundy.domain.exception.NoSearchResultException
-import com.foundy.domain.usecase.auth.IsSignedInUseCase
 import com.foundy.domain.usecase.messaging.SubscribeToUseCase
 import com.foundy.domain.usecase.messaging.UnsubscribeFromUseCase
 import com.foundy.domain.usecase.keyword.AddKeywordUseCase
 import com.foundy.domain.usecase.keyword.ReadKeywordListUseCase
 import com.foundy.domain.usecase.keyword.RemoveKeywordUseCase
 import com.foundy.domain.usecase.notice.HasSearchResultUseCase
-import com.foundy.hansungnotification.fake.FakeAuthRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeKeywordRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeMessagingRepositoryImpl
 import com.foundy.hansungnotification.fake.FakeNoticeRepositoryImpl
 import com.foundy.presentation.utils.KeywordValidator
-import com.foundy.presentation.view.keyword.KeywordViewModel
+import com.foundy.presentation.view.keyword.KeywordFragmentViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import okhttp3.MediaType
@@ -25,22 +23,20 @@ import retrofit2.HttpException
 import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class KeywordViewModelTest {
+class KeywordFragmentViewModelTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
     private val fakeKeywordRepository = FakeKeywordRepositoryImpl()
     private val fakeMessagingRepository = FakeMessagingRepositoryImpl()
-    private val fakeAuthRepository = FakeAuthRepositoryImpl()
     private val fakeNoticeRepository = FakeNoticeRepositoryImpl()
 
-    private val viewModel = KeywordViewModel(
+    private val viewModel = KeywordFragmentViewModel(
         ReadKeywordListUseCase(fakeKeywordRepository),
         AddKeywordUseCase(fakeKeywordRepository),
         RemoveKeywordUseCase(fakeKeywordRepository),
         SubscribeToUseCase(fakeMessagingRepository),
         UnsubscribeFromUseCase(fakeMessagingRepository),
-        IsSignedInUseCase(fakeAuthRepository),
         HasSearchResultUseCase(fakeNoticeRepository),
         testDispatcher
     )

--- a/data/src/main/java/com/foundy/data/di/DatabaseReferenceModule.kt
+++ b/data/src/main/java/com/foundy/data/di/DatabaseReferenceModule.kt
@@ -1,0 +1,30 @@
+package com.foundy.data.di
+
+import com.foundy.data.reference.DatabaseReferenceGetter
+import com.foundy.data.reference.KeywordsReferenceGetter
+import com.foundy.data.reference.UserKeywordsReferenceGetter
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class DatabaseReferenceModule {
+
+    @Singleton
+    @Provides
+    @Named("keywords")
+    fun provideKeywordsReference(): DatabaseReferenceGetter {
+        return KeywordsReferenceGetter()
+    }
+
+    @Singleton
+    @Provides
+    @Named("userKeywords")
+    fun provideUserKeywordsReference(): DatabaseReferenceGetter {
+        return UserKeywordsReferenceGetter()
+    }
+}

--- a/data/src/main/java/com/foundy/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/foundy/data/di/RepositoryModule.kt
@@ -1,6 +1,7 @@
 package com.foundy.data.di
 
 import com.foundy.data.api.NoticeApi
+import com.foundy.data.reference.DatabaseReferenceGetter
 import com.foundy.data.repository.*
 import com.foundy.data.source.favorite.FavoriteLocalDataSource
 import com.foundy.data.source.query.QueryLocalDataSource
@@ -9,6 +10,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
 import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
@@ -29,8 +31,11 @@ class RepositoryModule {
 
     @Provides
     @Singleton
-    fun provideKeywordRepository(): KeywordRepository {
-        return KeywordRepositoryImpl()
+    fun provideKeywordRepository(
+        @Named("keywords") keywordsReferenceGetter: DatabaseReferenceGetter,
+        @Named("userKeywords") userKeywordsReferenceGetter: DatabaseReferenceGetter
+    ): KeywordRepository {
+        return KeywordRepositoryImpl(keywordsReferenceGetter, userKeywordsReferenceGetter)
     }
 
     @Provides
@@ -41,8 +46,11 @@ class RepositoryModule {
 
     @Provides
     @Singleton
-    fun provideMessagingRepository(): MessagingRepository {
-        return MessagingRepositoryImpl()
+    fun provideMessagingRepository(
+        @Named("keywords") keywordsReferenceGetter: DatabaseReferenceGetter,
+        @Named("userKeywords") userKeywordsReferenceGetter: DatabaseReferenceGetter
+    ): MessagingRepository {
+        return MessagingRepositoryImpl(keywordsReferenceGetter, userKeywordsReferenceGetter)
     }
 
     @Provides

--- a/data/src/main/java/com/foundy/data/reference/DatabaseReferenceGetter.kt
+++ b/data/src/main/java/com/foundy/data/reference/DatabaseReferenceGetter.kt
@@ -1,0 +1,7 @@
+package com.foundy.data.reference
+
+import com.google.firebase.database.DatabaseReference
+
+interface DatabaseReferenceGetter {
+    operator fun invoke(): DatabaseReference
+}

--- a/data/src/main/java/com/foundy/data/reference/KeywordsReferenceGetter.kt
+++ b/data/src/main/java/com/foundy/data/reference/KeywordsReferenceGetter.kt
@@ -1,0 +1,12 @@
+package com.foundy.data.reference
+
+import com.foundy.data.constant.FirebaseConstant
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.ktx.database
+import com.google.firebase.ktx.Firebase
+
+class KeywordsReferenceGetter : DatabaseReferenceGetter {
+    override fun invoke(): DatabaseReference {
+        return Firebase.database.reference.child(FirebaseConstant.KEYWORDS)
+    }
+}

--- a/data/src/main/java/com/foundy/data/reference/UserKeywordsReferenceGetter.kt
+++ b/data/src/main/java/com/foundy/data/reference/UserKeywordsReferenceGetter.kt
@@ -1,0 +1,23 @@
+package com.foundy.data.reference
+
+import com.foundy.data.constant.FirebaseConstant
+import com.foundy.domain.exception.NotSignedInException
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.database.DatabaseReference
+import com.google.firebase.database.ktx.database
+import com.google.firebase.ktx.Firebase
+
+/**
+ * 사용자의 키워드 목록의 Database reference를 반환하는 객체이다.
+ *
+ * 반드시 로그인이 된 상태에서 [invoke]를 호출해야한다.
+ */
+class UserKeywordsReferenceGetter : DatabaseReferenceGetter {
+    override fun invoke(): DatabaseReference {
+        val uid = Firebase.auth.uid ?: throw NotSignedInException()
+        return Firebase.database.reference
+            .child(FirebaseConstant.USERS)
+            .child(uid)
+            .child(FirebaseConstant.KEYWORDS)
+    }
+}

--- a/data/src/main/java/com/foundy/data/repository/KeywordRepositoryImpl.kt
+++ b/data/src/main/java/com/foundy/data/repository/KeywordRepositoryImpl.kt
@@ -1,36 +1,31 @@
 package com.foundy.data.repository
 
 import android.util.Log
-import com.foundy.data.constant.FirebaseConstant.USERS
-import com.foundy.data.constant.FirebaseConstant.KEYWORDS
-import com.foundy.domain.exception.NotSignedInException
+import com.foundy.data.reference.DatabaseReferenceGetter
 import com.foundy.domain.model.Keyword
 import com.foundy.domain.repository.KeywordRepository
 import com.google.android.gms.tasks.OnCompleteListener
-import com.google.firebase.auth.ktx.auth
 import com.google.firebase.database.*
-import com.google.firebase.database.ktx.database
-import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+import javax.inject.Named
+import com.foundy.domain.exception.NotSignedInException
 
-class KeywordRepositoryImpl : KeywordRepository {
+class KeywordRepositoryImpl @Inject constructor(
+    @Named("keywords") private val keywordsReferenceGetter: DatabaseReferenceGetter,
+    @Named("userKeywords") private val userKeywordsReferenceGetter: DatabaseReferenceGetter
+) : KeywordRepository {
 
-    private val keywordsReference = Firebase.database.reference.child(KEYWORDS)
-
-    private val userKeywordsReference: DatabaseReference?
-        get() {
-            val uid = Firebase.auth.uid ?: return null
-            return Firebase.database.reference
-                .child(USERS)
-                .child(uid)
-                .child(KEYWORDS)
-        }
-
+    /**
+     * 유저의 키워드 목록 흐름을 반환한다.
+     *
+     * 반드시 이 함수를 호출하기 전에 로그인이 되어있어야 한다. 그렇지 않으면 [NotSignedInException]을 던진다.
+     */
     override fun getAll(): Flow<Result<List<Keyword>>> = callbackFlow {
-        val reference = userKeywordsReference ?: throw NotSignedInException()
+        val reference = userKeywordsReferenceGetter()
         val postListener = object : ValueEventListener {
             override fun onCancelled(error: DatabaseError) {
                 this@callbackFlow.trySendBlocking(Result.failure(error.toException()))
@@ -47,22 +42,32 @@ class KeywordRepositoryImpl : KeywordRepository {
         awaitClose { reference.removeEventListener(postListener) }
     }
 
+    /**
+     * 키워드를 추가한다.
+     *
+     * 반드시 이 함수를 호출하기 전에 로그인이 되어있어야 한다. 그렇지 않으면 [NotSignedInException]을 던진다.
+     */
     override fun add(keyword: Keyword) {
-        val userRef = userKeywordsReference ?: throw NotSignedInException()
+        val userRef = userKeywordsReferenceGetter()
         userRef.child(keyword.title)
             .setValue(1)
             .addOnCompleteListener(onCompleteListener)
-        keywordsReference.child(keyword.title)
+        keywordsReferenceGetter().child(keyword.title)
             .setValue(ServerValue.increment(1))
             .addOnCompleteListener(onCompleteListener)
     }
 
+    /**
+     * 키워드를 삭제한다.
+     *
+     * 반드시 이 함수를 호출하기 전에 로그인이 되어있어야 한다. 그렇지 않으면 [NotSignedInException]을 던진다.
+     */
     override fun remove(keyword: Keyword) {
-        val userRef = userKeywordsReference ?: throw NotSignedInException()
+        val userRef = userKeywordsReferenceGetter()
         userRef.child(keyword.title)
             .removeValue()
             .addOnCompleteListener(onCompleteListener)
-        keywordsReference.child(keyword.title)
+        keywordsReferenceGetter().child(keyword.title)
             .setValue(ServerValue.increment(-1))
             .addOnCompleteListener(onCompleteListener)
     }

--- a/data/src/main/java/com/foundy/data/repository/KeywordRepositoryImpl.kt
+++ b/data/src/main/java/com/foundy/data/repository/KeywordRepositoryImpl.kt
@@ -30,11 +30,7 @@ class KeywordRepositoryImpl : KeywordRepository {
         }
 
     override fun getAll(): Flow<Result<List<Keyword>>> = callbackFlow {
-        val reference = userKeywordsReference
-        if (reference == null) {
-            this@callbackFlow.trySendBlocking(Result.failure(NotSignedInException()))
-            return@callbackFlow
-        }
+        val reference = userKeywordsReference ?: throw NotSignedInException()
         val postListener = object : ValueEventListener {
             override fun onCancelled(error: DatabaseError) {
                 this@callbackFlow.trySendBlocking(Result.failure(error.toException()))

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordActivity.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordActivity.kt
@@ -19,7 +19,7 @@ class KeywordActivity : AppCompatActivity() {
     private var _binding: ActivityKeywordBinding? = null
     private val binding: ActivityKeywordBinding get() = requireNotNull(_binding)
 
-    private val viewModel: KeywordViewModel by viewModels()
+    private val viewModel: KeywordActivityViewModel by viewModels()
 
     companion object {
         fun getIntent(context: Context): Intent {

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordActivityViewModel.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordActivityViewModel.kt
@@ -1,0 +1,14 @@
+package com.foundy.presentation.view.keyword
+
+import androidx.lifecycle.*
+import com.foundy.domain.usecase.auth.IsSignedInUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class KeywordActivityViewModel @Inject constructor(
+    private val isSignedInUseCase: IsSignedInUseCase
+) : ViewModel() {
+
+    fun isSignedIn() = isSignedInUseCase()
+}

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragment.kt
@@ -37,7 +37,7 @@ class KeywordFragment(
     @VisibleForTesting factory: (() -> ViewModelProvider.Factory)? = null
 ) : Fragment(R.layout.fragment_keyword) {
 
-    private val viewModel: KeywordViewModel by activityViewModels(factory)
+    private val viewModel: KeywordFragmentViewModel by activityViewModels(factory)
 
     companion object {
 

--- a/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragmentViewModel.kt
+++ b/presentation/src/main/java/com/foundy/presentation/view/keyword/KeywordFragmentViewModel.kt
@@ -3,7 +3,6 @@ package com.foundy.presentation.view.keyword
 import androidx.lifecycle.*
 import com.foundy.domain.exception.NoSearchResultException
 import com.foundy.domain.model.Keyword
-import com.foundy.domain.usecase.auth.IsSignedInUseCase
 import com.foundy.domain.usecase.messaging.SubscribeToUseCase
 import com.foundy.domain.usecase.messaging.UnsubscribeFromUseCase
 import com.foundy.domain.usecase.keyword.AddKeywordUseCase
@@ -22,13 +21,12 @@ import javax.inject.Inject
 import javax.inject.Named
 
 @HiltViewModel
-class KeywordViewModel @Inject constructor(
+class KeywordFragmentViewModel @Inject constructor(
     readKeywordListUseCase: ReadKeywordListUseCase,
     private val addKeywordUseCase: AddKeywordUseCase,
     private val removeKeywordUseCase: RemoveKeywordUseCase,
     private val subscribeToUseCase: SubscribeToUseCase,
     private val unsubscribeFromUseCase: UnsubscribeFromUseCase,
-    private val isSignedInUseCase: IsSignedInUseCase,
     private val hasSearchResultUseCase: HasSearchResultUseCase,
     @Named("Main") private val dispatcher: CoroutineDispatcher = Dispatchers.Main
 ) : ViewModel() {
@@ -65,8 +63,6 @@ class KeywordViewModel @Inject constructor(
     fun unsubscribeFrom(topic: String, onFailure: (Exception) -> Unit) {
         unsubscribeFromUseCase(topic, onFailure)
     }
-
-    fun isSignedIn() = isSignedInUseCase()
 
     /**
      * 키워드의 유효성 검사와 해당 키워드가 공지사항 검색결과에 존재하는지 확인한다.


### PR DESCRIPTION
Fixes #33 

로그인을 하지 않은 상태에서 `getAll()` 함수를 호출하였더니 `awaitClose`함수가 호출되지 않아 발생한 문제였다.
Framgent와 Activity의 `viewModel`을 각각 나누어서 로그인 하지 않았을 때 `getAll` 함수를 호출하지 않도록 하였다. 또한 로그인 하지 않은 상태에서 `getAll`를 호출하는 경우 곧바로 예외를 던지도록 하였다.

추가적으로 Database reference를 얻는 것을 DI를 하도록 수정했다.